### PR TITLE
fix(package): Fix exception when an empty security block is defined

### DIFF
--- a/src/extract/v3/extractPaths.js
+++ b/src/extract/v3/extractPaths.js
@@ -29,6 +29,14 @@ const extractPaths = ({ security, servers, paths }, options = {}) => {
   const defaultBasePath = basePath(servers, variables)
   const defaultSecurity = normaliseSecurity(security)
 
+  const pathSecurity = (opSecurity, defaultSecurity) => {
+    const pathSecurity = normaliseSecurity(opSecurity)
+    if (pathSecurity === null) {
+      return undefined
+    }
+    return pathSecurity || defaultSecurity
+  }
+
   const reduceRoutes = (acc, elem) => {
     METHODS.forEach(method => {
       const op = paths[elem][method]
@@ -41,7 +49,7 @@ const extractPaths = ({ security, servers, paths }, options = {}) => {
           method,
           route: normaliseRoute(`${trimmedBase}${elem}`),
           operationId: normaliseOperationId(op.operationId, apiSeparator),
-          security: normaliseSecurity(op.security) || defaultSecurity,
+          security: pathSecurity(op.security, defaultSecurity),
           middleware: normaliseMiddleware(middleware, op['x-middleware'])
         })
       }

--- a/src/normalise/v3/normaliseSecurity.js
+++ b/src/normalise/v3/normaliseSecurity.js
@@ -4,6 +4,7 @@ const normaliseV2Security = require('../v2/normaliseSecurity')
 const normaliseSecurity = security => {
   if (!security) return
   const [first] = security
+  if (!first) return null
   const [key] = Object.keys(first)
   const value = first[key]
   if (value.length === 0) return key

--- a/test/unit/extract/v3/extractPaths.test.js
+++ b/test/unit/extract/v3/extractPaths.test.js
@@ -67,4 +67,47 @@ describe('src/extract/v3/extractPaths', () => {
   it('returns the expected paths', () => {
     expect(paths).to.deep.equal(expected)
   })
+
+  context('root level security opt-out', () => {
+    const api = {
+      servers: [{ url: '/api/v1' }],
+      paths: {
+        '/': {
+          get: {
+            servers: [{ url: '/' }],
+            tags: ['root'],
+            operationId: 'root',
+            security: []
+          }
+        }
+      },
+      security: [
+        {
+          bearerAuth: []
+        }
+      ]
+      // components: {
+      //   securitySchemes
+      // }
+    }
+    const expected = [
+      {
+        method: 'get',
+        route: '/',
+        operationId: 'root',
+        security: undefined,
+        middleware: []
+      }
+    ]
+
+    let paths
+
+    before(() => {
+      paths = extractPaths(api)
+    })
+
+    it('returns the expected paths', () => {
+      expect(paths).to.deep.equal(expected)
+    })
+  })
 })

--- a/test/unit/normalise/v3/normaliseSecurity.test.js
+++ b/test/unit/normalise/v3/normaliseSecurity.test.js
@@ -36,4 +36,11 @@ describe('src/normalise/v3/normaliseSecurity', () => {
       expect(normaliseSecurity()).to.be.undefined
     })
   })
+
+  context('given empty security block', () => {
+    context('it returns null security', () => {
+      const security = []
+      doTest(security, null)
+    })
+  })
 })


### PR DESCRIPTION
When global security method is defined for all the operations and a specific operation's [security is _non-secure_](https://swagger.io/docs/specification/authentication/#security), the library would throw an exception:
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at normaliseSecurity (/usr/src/app/node_modules/swagger-routes-express/src/normalise/v3/normaliseSecurity.js:9:24)
    at /usr/src/app/node_modules/swagger-routes-express/src/extract/v3/extractPaths.js:44:21
    at Array.forEach (<anonymous>)
    at reduceRoutes (/usr/src/app/node_modules/swagger-routes-express/src/extract/v3/extractPaths.js:33:13)
    at Array.reduce (<anonymous>)
    at extractPaths (/usr/src/app/node_modules/swagger-routes-express/src/extract/v3/extractPaths.js:52:29)
    at connector (/usr/src/app/node_modules/swagger-routes-express/src/connector/index.js:33:17)
    at /usr/src/app/src/routers/api/v1/ApiV1Router.ts:27:17
```

Example OpenAPI spec:
```yml
openapi: 3.0.0
paths:
  /users/login:
    post:
      security: []
      description: Exchange email and password for JWT token
      requestBody:
        content:
          application/json:
            schema:
              type: object
              required:
                - email
                - password
              properties:
                email:
                  type: string
                  format: email
                  example: john.fish@email.email
                password:
                  type: string
                  format: password
                  example: MySecertPassword1337
      responses:
        200:
          description: Token
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Token'
        400:
          $ref: '#/components/responses/BadRequest'
security:
  - bearerAuth: []
components:
  securitySchemes:
    bearerAuth:
      type: http
      scheme: bearer
      bearerFormat: JWT
  schemas:
    Token:
      type: object
      properties:
        token:
          type: string
          format: jwt
          example: |
            eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRmlzaCIsImlhdCI6MTUxNjIzOTAyMn0.FGKfLFKD9DDu4FGNo9gcJAKAh2ucDh_gJ-LLqEQFcWA
  responses:
    BadRequest:
      description: Validation failed
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/ValidationError'
```