### PR TITLE
[bug fix, #95] fixed apiDefinition type and renamed apiDoc to apiDefinition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,5 +35,5 @@ declare module 'swagger-routes-express' {
   }
 
   export function connector(api: Controllers, apiDefinition: object, options?: ConnectorOptions): (router: Router) => void;
-  export function summarise(apiDoc, options?: SummariseOptions): void;
+  export function summarise(apiDefinition: object, options?: SummariseOptions): void;
 }

--- a/src/connector/index.js
+++ b/src/connector/index.js
@@ -7,8 +7,8 @@ const extractV3Paths = require('../extract/v3/extractPaths')
 
 /**
  *  Connect the route controllers defined in `api` with the
- *  `operationIds` and `paths` in the `apiDoc` supplied.
- *  The `apiDoc` may be either a Swagger version 2,
+ *  `operationIds` and `paths` in the `apiDefinition` supplied.
+ *  The `apiDefinition` may be either a Swagger version 2,
  *  or OpenAPI version 3 document.
  *  The options allowed, with their defaults are as follows:
  *  {
@@ -23,14 +23,14 @@ const extractV3Paths = require('../extract/v3/extractPaths')
  *    INVALID_VERSION = errors.INVALID_VERSION
  *  }
  */
-const connector = (api, apiDoc, options = {}) => {
+const connector = (api, apiDefinition, options = {}) => {
   const { INVALID_VERSION = ERRORS.INVALID_VERSION, onCreateRoute } = options
-  const version = extractVersion(apiDoc)
+  const version = extractVersion(apiDefinition)
   if (!version) throw new Error(INVALID_VERSION)
 
   const extractPaths = version === 2 ? extractV2Paths : extractV3Paths
 
-  const paths = extractPaths(apiDoc, options)
+  const paths = extractPaths(apiDefinition, options)
 
   return app => {
     paths.forEach(({ method, route, operationId, security, middleware }) => {

--- a/src/summarise/index.js
+++ b/src/summarise/index.js
@@ -9,18 +9,18 @@ const summariseApiV3 = require('./v3/summariseApi')
  *    info: { name, description, version },
  *    paths: { [method]: ['/', '/ping', '/v1/api/function/:param'] }
  *  }
- *  @param apiDoc The imported YML or JSON api document.
+ *  @param apiDefinition The imported YML or JSON api document.
  *  @options Optional INVALID_VERSION message.
  *  @return { info, paths } API summary object.
  */
-const summarise = (apiDoc, options = {}) => {
+const summarise = (apiDefinition, options = {}) => {
   const { INVALID_VERSION = ERRORS.INVALID_VERSION } = options
-  const version = extractVersion(apiDoc)
+  const version = extractVersion(apiDefinition)
   if (!version) throw new Error(INVALID_VERSION)
 
   const summariseApi = version === 2 ? summariseApiV2 : summariseApiV3
 
-  return summariseApi(apiDoc)
+  return summariseApi(apiDefinition)
 }
 
 module.exports = summarise


### PR DESCRIPTION
Referencing #95 

I noticed I was using `apiDoc` and `apiDefinition` both to refer to the same thing so I have standardised on `apiDefinition` and fixed the missing `: object` in the type definition.

