### PR TITLE
Updated connectController so array can be used as route controllers

### DIFF
--- a/src/connector/connectController.js
+++ b/src/connector/connectController.js
@@ -4,11 +4,16 @@ const nf = require('../routes/notFound')
 const connectController = (api, operationId, options) => {
   const { notFound = nf, notImplemented = ni } = options
 
-  return operationId
-    ? typeof api[operationId] === 'function'
-      ? api[operationId]
-      : notImplemented
-    : notFound
+  if (!operationId) return notFound
+  if (typeof api[operationId] === 'function') return api[operationId]
+  if (Array.isArray(api[operationId])) {
+    if (api[operationId].reduce((isFun, fun) => typeof fun === 'function' && isFun, true)) {
+      return api[operationId]
+    } else {
+      return notImplemented
+    }
+  }
+  return notImplemented
 }
 
 module.exports = connectController

--- a/test/unit/connector/connectController.test.js
+++ b/test/unit/connector/connectController.test.js
@@ -7,7 +7,10 @@ describe('src/connector/connectController', () => {
   const notFound = 'not found'
   const options = { notFound, notImplemented }
   const api = {
-    test: () => {}
+    test: () => {},
+    notAFunction: 'foobar',
+    functionArray: [() => {}, () => {}],
+    notFunctionArray: [() => {}, 'foobar']
   }
 
   context('given no operationId', () => {
@@ -27,6 +30,27 @@ describe('src/connector/connectController', () => {
       expect(connectController(api, 'test', options)).to.equal(api.test)
     })
   })
+
+  context('given a operationId that refers to something not a function', () => {
+    it('returns notImplemented', () => {
+      expect(connectController(api, 'notAFunction', options)).to.equal(notImplemented)
+    })
+  })
+
+  context('given an operationId that refers to an array of functions', () => {
+    it('returns the correct api controller', () => {
+      expect(connectController(api, 'functionArray', options)).to.equal(api.functionArray)
+    })
+  })
+
+  context(
+    'given an operationId that refers to an array with elements that are not functions',
+    () => {
+      it('return notImplemented', () => {
+        expect(connectController(api, 'notFunctionArray', options)).to.equal(notImplemented)
+      })
+    }
+  )
 
   context('given default options', () => {
     it('returns a function', () => {


### PR DESCRIPTION
What the title says. I updated the connectController so that route controllers can now either be functions or arrays of functions. This way multiple middleware functions can be strung together to handle a route, making code reuse easier.