### PR TITLE
Allow head requests to work for routes with no other method

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-const METHODS = ['get', 'post', 'patch', 'put', 'delete']
+const METHODS = ['get', 'post', 'patch', 'put', 'delete', 'head']
 
 module.exports = {
   METHODS


### PR DESCRIPTION
Hi,
I noticed that having are route with only a HEAD request defined leads to it being filtered out [here](https://github.com/davesag/swagger-routes-express/blob/f31a7510ce8e48f4b780b919bc96c73294ee743a/src/extract/v3/extractPaths.js#L40).
Adding `head` to the list of methods seems to fix this issue.